### PR TITLE
Check api limit and fix since_tag commit fetch

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -42,6 +42,12 @@ module GitHubChangelogGenerator
       @tag_times_hash = {}
       @fetcher        = GitHubChangelogGenerator::OctoFetcher.new(options)
       @sections       = []
+      if @options[:since_commit].nil? && !@options[:since_tag].nil?
+        since_tag_time = get_time_of_specific_tags(@options[:since_tag])
+        @options[:since_commit] =  since_tag_time
+     else
+        @options[:since_commit]   = @options[:since_commit]
+     end
     end
 
     # Main function to start changelog generation

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -72,6 +72,16 @@ module GitHubChangelogGenerator
       end
     end
 
+    # @param [Hash]tag
+    # @return [Time] Get Time of specific Tag
+    def get_time_of_specific_tags(specific_tag)
+      all_tags = @fetcher.get_all_tags
+      all_sorted_tags = sort_tags_by_date(all_tags)
+      @sorted_tags   = filter_included_tags(all_sorted_tags)
+      tag_hash = sorted_tags.select { |tag| specific_tag == tag["name"] }
+      get_time_of_tag(tag_hash.first)
+    end
+
     # Detect link, name and time for specified tag.
     #
     # @param [Hash] newer_tag newer tag. Can be nil, if it's Unreleased section.

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -6,7 +6,6 @@ require "async"
 require "async/barrier"
 require "async/semaphore"
 require "async/http/faraday"
-require "pry"
 
 module GitHubChangelogGenerator
   # A Fetcher responsible for all requests to GitHub and all basic manipulation with related data

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -216,6 +216,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
 
         issues.each do |issue|
           semaphore.async do
+            check_limit_api()
             issue["events"] = []
             iterate_pages(client, "issue_events", issue["number"], **preview) do |new_event|
               issue["events"].concat(new_event)
@@ -444,7 +445,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'"
 
         (2..last_page).each do |page|
           parent.async do
-            check_limit_api()
+            #check_limit_api()
             data = check_github_response { client.send(method, user_project, *arguments, page: page, **options) }
             yield data
           end


### PR DESCRIPTION
Draft PR for he following issue
https://github.com/github-changelog-generator/github-changelog-generator/issues/645
Auto Release workflow is failing with the following error
`Octokit::AbuseDetected: GET https://api.github.com/repos/puppetlabs/puppetlabs-apache/issues/1236/events?per_page=100: 403 `
Possible fix is to add the api limit function and also to fetch only the tag specified with since_tag
As of now its fetching all tags irrespective of the tag specified in since_tag function

Fix is needed for the following line where its fetching all tags
https://github.com/puppetlabs/github-changelog-generator/blob/main/lib/github_changelog_generator/generator/generator_tags.rb#L10

Possible solution is 
`   if @options[:since].nil? && !@options[:since_tag].nil?
        @options[:since] =  get_time_of_tag(@options[:since_tag]) ## (here it accept hash value of tags and not string so need a function to fetch specific value from tag hash and pass to this function)
     else
        @options[:since]   = @options[:since]
     end
      @fetcher        = GitHubChangelogGenerator::OctoFetcher.new(options)`

Test Results
 https://github.com/puppetlabs/puppetlabs-tomcat/runs/3241234806?check_suite_focus=true
https://github.com/puppetlabs/puppetlabs-stdlib/runs/3241422191?check_suite_focus=true
https://github.com/puppetlabs/puppetlabs-firewall/runs/3241420148?check_suite_focus=true
https://github.com/puppetlabs/puppetlabs-apache/runs/3241418146?check_suite_focus=true